### PR TITLE
Solve the bug of undefined num_mips

### DIFF
--- a/tem2ng/__init__.py
+++ b/tem2ng/__init__.py
@@ -264,6 +264,7 @@ def upload(ctx, source, destination, z, clear_progress, num_mips):
     
     def process(filename):
         nonlocal tile_id_map
+        nonlocal num_mips
         if os.path.splitext(filename)[1] == ".jxl":
             with open(os.path.join(subtiles_dir, filename), "rb") as f:
                 binary = f.read()


### PR DESCRIPTION
There is a small bug that prevents upload because num_mips is undefined in the function. Which is solve by indicating it as a nonlocal variable