### PR TITLE
Update on capabilities for uploading from object storage

### DIFF
--- a/tem2ng/__init__.py
+++ b/tem2ng/__init__.py
@@ -264,6 +264,7 @@ def upload(ctx, source, destination, z, clear_progress, num_mips):
     
     def process(filename):
         nonlocal tile_id_map
+        nonlocal num_mips
         if os.path.splitext(filename)[1] == ".jxl":
             with open(os.path.join(subtiles_dir, filename), "rb") as f:
                 binary = f.read()

--- a/tem2ng/__init__.py
+++ b/tem2ng/__init__.py
@@ -340,8 +340,7 @@ def xray(ctx, source, destination, resolution):
         fname for fname in all_files
         if (
             os.path.isfile(os.path.join(subtiles_dir, fname))
-            and (os.path.splitext(fname)[1] == ".tif" or
-            os.path.splitext(fname)[1] == ".tiff")
+            and (os.path.splitext(fname)[1] in [".tif", ".tiff", ".png", ".jpg", ".jpeg"])
         )
     ]
     all_files.sort()


### PR DESCRIPTION
Add capabilities to read source using cloudfiles. Makes it possible to upload TEM previews to neuroglancer from the object storage bucket.